### PR TITLE
Update all projects to use the new Maven plugin (original repo updates)

### DIFF
--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -3,4 +3,6 @@ This directory is where you'll write all of your code!
 By default it contains a barebones web app. To run a local server, execute this
 command:
 
-mvn appengine:devserver
+```bash
+mvn package appengine:run
+```

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -27,10 +27,17 @@
 
   <build>
     <plugins>
+      <!-- Provides `mvn package appengine:run` for local testing
+           and `mvn package appengine:deploy` for deploying. -->
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <!-- TODO: set project ID. -->
+          <deploy.projectId>cell-step-2020</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/portfolio/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-1-setup/github-setup-walkthrough.md
+++ b/walkthroughs/week-1-setup/github-setup-walkthrough.md
@@ -101,7 +101,8 @@ To give your host access to your repo, add them as a collaborator.
 1.  Go to the `Settings` tab.
 1.  Select `Collaborators`. (*Note*: If you don't see this,
     look for `Manage Access` -> `Invite a Collaborator` instead)
-1.  Add your Project Advisor using their GitHub username or email address.
+1.  Add your host using their GitHub username or email address (you can send
+them a quick message to confirm their Github username).
 
 Your host can now help with code reviews.
 
@@ -145,7 +146,7 @@ file.
 
 This file contains the content that shows in your repo's GitHub page.
 Change it to say "This repo contains [your name]'s portfolio and
-SPS projects."
+STEP projects."
 
 The `README.md` file now belongs to you. You should feel free to customize it
 and make it your own!

--- a/walkthroughs/week-2-web-development/examples/stanley/pom.xml
+++ b/walkthroughs/week-2-web-development/examples/stanley/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-2-web-development/examples/stanley/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-2-web-development/examples/stanley/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-2-web-development/portfolio-walkthrough.md
+++ b/walkthroughs/week-2-web-development/portfolio-walkthrough.md
@@ -53,17 +53,29 @@ You'll learn more about these files in the following steps.
 
 ## Java 8
 
-Before you continue, set your default Java version to Java 8 by running this
-command:
+Before you continue, set your default Java version to Java 8.
+
+To do that, first open your `.bashrc` file by running this command:
 
 ```bash
+edit ~/.bashrc
+```
+
+This file sets up your console configuration. Copy this line into the end of
+that file:
+
+```
 sudo update-java-alternatives -s java-1.8.0-openjdk-amd64 && export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
 ```
 
+Save and close the `.bashrc` file, and then execute it using this command:
+
+```bash
+source ~/.bashrc
+```
+
 You can ignore any error messages about not being able to find alternatives for
-various plugins. Your Java version setting will persist unless you restart your
-Cloud shell instance. To permanently switch to Java 8, add the command above to
-your `.bashrc` file.
+various plugins.
 
 ### Why Java 8?
 
@@ -71,13 +83,14 @@ Google Cloud recently announced support for Java 11, but Java 11 is not
 backwards compatible with every library in these walkthroughs. To make sure
 everything will work as expected, please use Java 8.
 
-To make sure you're using the correct version of Java, run this command:
+To make sure you're using the correct version of Java, run these commands:
 
 ```bash
+echo $JAVA_HOME
 java -version
 ```
 
-If this command prints a version like `1.8.0_xxx`, then you're good to go!
+If these commands print a version like `1.8.0_xxx`, then you're good to go!
 
 ## Run a Development Server
 
@@ -93,7 +106,7 @@ cd portfolio
 Then execute this command:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 This command tells Maven to run an App Engine development server, which is
@@ -137,10 +150,10 @@ in the foreground, which will usually cause the program to abort.
 
 Whenever you change your code, you need to restart your server to see your
 changes. Press `ctrl + c` in the console to shut down your server, and then run
-the devserver command again:
+this command again:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 **Tip:** You can press the up arrow key to cycle through previous commands
@@ -175,7 +188,7 @@ Deploy the example webpage by `cd`-ing into the `stanley` directory and then
 running a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Then look through the files in the `stanley` project to see an example of HTML,
@@ -324,7 +337,7 @@ Remember, to run a dev server, you `cd` into a directory that contains a
 `pom.xml` file, and then you execute this command:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 When you see `Dev App Server is now running` in the console, click the
@@ -382,16 +395,17 @@ To deploy to a live server:
 -   Make sure your project is selected in the dropdown at the top.
 -   Find the **Project ID** on that page.
 -   Open the
-    <walkthrough-editor-open-file
-        filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-      appengine-web.xml
+    <walkthrough-editor-open-file filePath="step/portfolio/pom.xml">
+      pom.xml
     </walkthrough-editor-open-file>
     file.
 -   Change `YOUR_PROJECT_ID_HERE` to your project ID.
+-   Enable Cloud Build on your project by visiting https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview?project=YOUR_PROJECT_ID_HERE
+    - Will require enabling billing. See doc for Intern Dev Environment Setup https://docs.google.com/document/d/1_zKf_Vpb1lxnWLDhQ6IGcA6W95UBufr06SmmoJZY7iE/edit#heading=h.wzgtvu2xiuh3. You will be unable to deploy applications after November 30, 2019 without adding a billing instrument to your project. Please add one at https://console.cloud.google.com/billing/linkedaccount?YOUR_PROJECT_ID_HERE
 -   Execute this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 -   The first time you run this command, the console will give you a link. Open

--- a/walkthroughs/week-3-server/comments-walkthrough.md
+++ b/walkthroughs/week-3-server/comments-walkthrough.md
@@ -174,15 +174,14 @@ When you're happy with your comments feature and you're ready to show it to the
 world, you can deploy it to your live server!
 
 Last week, you should have added your project ID to your
-<walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+<walkthrough-editor-open-file filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file. If so, you can deploy to your live server by executing this command from
 the `portfolio` directory:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 -   The first time you run this command, the console will give you a link. Open

--- a/walkthroughs/week-3-server/examples/favorite-color/pom.xml
+++ b/walkthroughs/week-3-server/examples/favorite-color/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/favorite-color/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/favorite-color/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/form-submission/pom.xml
+++ b/walkthroughs/week-3-server/examples/form-submission/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/form-submission/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/form-submission/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/page-view-counter/pom.xml
+++ b/walkthroughs/week-3-server/examples/page-view-counter/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/page-view-counter/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/page-view-counter/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/random-quotes/pom.xml
+++ b/walkthroughs/week-3-server/examples/random-quotes/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/random-quotes/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/random-quotes/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/request-debugger/pom.xml
+++ b/walkthroughs/week-3-server/examples/request-debugger/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/request-debugger/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/request-debugger/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/server-stats/pom.xml
+++ b/walkthroughs/week-3-server/examples/server-stats/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/server-stats/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/server-stats/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/subtraction-game/pom.xml
+++ b/walkthroughs/week-3-server/examples/subtraction-game/pom.xml
@@ -33,9 +33,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/subtraction-game/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/subtraction-game/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/text-processor/pom.xml
+++ b/walkthroughs/week-3-server/examples/text-processor/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/text-processor/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/text-processor/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/examples/todo-list/pom.xml
+++ b/walkthroughs/week-3-server/examples/todo-list/pom.xml
@@ -42,9 +42,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-3-server/examples/todo-list/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-3-server/examples/todo-list/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-3-server/step-1-servlets-walkthrough.md
+++ b/walkthroughs/week-3-server/step-1-servlets-walkthrough.md
@@ -78,7 +78,7 @@ To see this in action, `cd` into the `page-view-counter` directory and then run
 a development server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Run this command and then click the

--- a/walkthroughs/week-3-server/step-2-fetch-walkthrough.md
+++ b/walkthroughs/week-3-server/step-2-fetch-walkthrough.md
@@ -66,7 +66,7 @@ Confirm that this works by `cd`-ing into the `random-quotes` directory and
 running a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Run this command and then click the

--- a/walkthroughs/week-3-server/step-4-post-walkthrough.md
+++ b/walkthroughs/week-3-server/step-4-post-walkthrough.md
@@ -73,7 +73,7 @@ To see this example in action, `cd` into the `text-processor` directory and
 then run a development server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Try submitting different values in the form and see how they're handled on the

--- a/walkthroughs/week-4-libraries/authentication/authentication-walkthrough.md
+++ b/walkthroughs/week-4-libraries/authentication/authentication-walkthrough.md
@@ -240,15 +240,14 @@ When you're happy with your feature and you're ready to show it to the world,
 you can deploy it to your live server!
 
 Your
-<walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+<walkthrough-editor-open-file filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-4-libraries/authentication/examples/hello-world/pom.xml
+++ b/walkthroughs/week-4-libraries/authentication/examples/hello-world/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/authentication/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/authentication/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/authentication/examples/shoutbox-v3/pom.xml
+++ b/walkthroughs/week-4-libraries/authentication/examples/shoutbox-v3/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/authentication/examples/shoutbox-v3/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/authentication/examples/shoutbox-v3/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/authentication/examples/user-nicknames/pom.xml
+++ b/walkthroughs/week-4-libraries/authentication/examples/user-nicknames/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/authentication/examples/user-nicknames/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/authentication/examples/user-nicknames/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/blobstore/blobstore-walkthrough.md
+++ b/walkthroughs/week-4-libraries/blobstore/blobstore-walkthrough.md
@@ -295,15 +295,14 @@ When you're happy with your feature and you're ready to show it to the world,
 you can deploy it to your live server!
 
 Your
-<walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+<walkthrough-editor-open-file filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world-fetch/pom.xml
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world-fetch/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world-fetch/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world-fetch/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -67,7 +67,7 @@ public class FormHandlerServlet extends HttpServlet {
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
     List<BlobKey> blobKeys = blobs.get("image");
 
-    // User submitted form without selecting a file, so we can't get a URL. (devserver)
+    // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {
       return null;
     }

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world-jsp/pom.xml
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world-jsp/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world-jsp/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world-jsp/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -67,7 +67,7 @@ public class FormHandlerServlet extends HttpServlet {
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
     List<BlobKey> blobKeys = blobs.get("image");
 
-    // User submitted form without selecting a file, so we can't get a URL. (devserver)
+    // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {
       return null;
     }

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world/pom.xml
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/blobstore/examples/hello-world/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
+++ b/walkthroughs/week-4-libraries/blobstore/examples/hello-world/src/main/java/com/google/sps/servlets/FormHandlerServlet.java
@@ -67,7 +67,7 @@ public class FormHandlerServlet extends HttpServlet {
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
     List<BlobKey> blobKeys = blobs.get(formInputElementName);
 
-    // User submitted form without selecting a file, so we can't get a URL. (devserver)
+    // User submitted form without selecting a file, so we can't get a URL. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {
       return null;
     }
@@ -89,7 +89,7 @@ public class FormHandlerServlet extends HttpServlet {
     ImagesService imagesService = ImagesServiceFactory.getImagesService();
     ServingUrlOptions options = ServingUrlOptions.Builder.withBlobKey(blobKey);
 
-    // To support running in Google Cloud Shell with AppEngine's devserver, we must use the relative
+    // To support running in Google Cloud Shell with AppEngine's dev server, we must use the relative
     // path to the image, rather than the path returned by imagesService which contains a host.
     try {
       URL url = new URL(imagesService.getServingUrl(options));

--- a/walkthroughs/week-4-libraries/charts/charts-walkthrough.md
+++ b/walkthroughs/week-4-libraries/charts/charts-walkthrough.md
@@ -39,7 +39,7 @@ The `examples` directory contains a `hello-world` project. You can `cd` into
 the `hello-world` directory and run a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 You should see a webpage that shows a pie chart.
@@ -91,7 +91,7 @@ sightings from a CSV file and uses it to create a chart. You can `cd` into the
 `bigfoot-sightings` directory and then run a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 When you view your dev server in your browser, you should see a line chart that
@@ -136,7 +136,7 @@ You can `cd` into the
 `favorite-colors` directory and then run a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 When you view your dev server in your browser, you should see a webapp that
@@ -172,15 +172,14 @@ When you're happy with your feature and you're ready to show it to the world,
 deploy it to your live server!
 
 Your
-<walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+<walkthrough-editor-open-file filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-4-libraries/charts/examples/bigfoot-sightings/README.md
+++ b/walkthroughs/week-4-libraries/charts/examples/bigfoot-sightings/README.md
@@ -12,6 +12,6 @@ which I found by searching on
 
 You can run this locally by executing this command:
 
-```
-mvn appengine:devserver
+```bash
+mvn package appengine:run
 ```

--- a/walkthroughs/week-4-libraries/charts/examples/bigfoot-sightings/pom.xml
+++ b/walkthroughs/week-4-libraries/charts/examples/bigfoot-sightings/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/charts/examples/bigfoot-sightings/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/charts/examples/bigfoot-sightings/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/charts/examples/favorite-colors/pom.xml
+++ b/walkthroughs/week-4-libraries/charts/examples/favorite-colors/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/charts/examples/favorite-colors/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/charts/examples/favorite-colors/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/charts/examples/hello-world/pom.xml
+++ b/walkthroughs/week-4-libraries/charts/examples/hello-world/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/charts/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/charts/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/README.md
+++ b/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/README.md
@@ -10,8 +10,8 @@ environment variable is set and that you've enabled the
 [Vision API](https://console.cloud.google.com/apis/library/vision.googleapis.com),
 and then execute this command:
 
-```
-mvn appengine:devserver
+```bash
+mvn package appengine:run
 ```
 
 Then open a web browser to `http://localhost:8080/index.jsp`.

--- a/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/pom.xml
+++ b/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/pom.xml
@@ -40,9 +40,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/src/main/java/com/google/sps/servlets/ImageAnalysisServlet.java
+++ b/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/src/main/java/com/google/sps/servlets/ImageAnalysisServlet.java
@@ -98,7 +98,7 @@ public class ImageAnalysisServlet extends HttpServlet {
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
     List<BlobKey> blobKeys = blobs.get("image");
 
-    // User submitted form without selecting a file, so we can't get a BlobKey. (devserver)
+    // User submitted form without selecting a file, so we can't get a BlobKey. (dev server)
     if (blobKeys == null || blobKeys.isEmpty()) {
       return null;
     }

--- a/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/image-analysis/examples/image-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/image-analysis/image-analysis-walkthrough.md
+++ b/walkthroughs/week-4-libraries/image-analysis/image-analysis-walkthrough.md
@@ -177,15 +177,14 @@ When you're happy with your feature and you're ready to show it to the world,
 you can deploy it to your live server!
 
 Your
-<walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+<walkthrough-editor-open-file filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-4-libraries/maps/examples/google-tour/pom.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/google-tour/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/maps/examples/google-tour/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/google-tour/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/maps/examples/hello-world/pom.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/hello-world/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/maps/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/hello-world/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/maps/examples/info-window/pom.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/info-window/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/maps/examples/info-window/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/info-window/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/maps/examples/marker-storage/pom.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/marker-storage/pom.xml
@@ -46,9 +46,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/maps/examples/marker-storage/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/marker-storage/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/maps/examples/marker/pom.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/marker/pom.xml
@@ -28,9 +28,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/maps/examples/marker/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/marker/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/maps/examples/ufos/README.md
+++ b/walkthroughs/week-4-libraries/maps/examples/ufos/README.md
@@ -11,8 +11,8 @@ I found by searching on
 
 You can run this locally by executing this command:
 
-```
-mvn appengine:devserver
+```bash
+mvn package appengine:run
 ```
 
 ![UFO data on map](screenshot-1.png)

--- a/walkthroughs/week-4-libraries/maps/examples/ufos/pom.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/ufos/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/maps/examples/ufos/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/maps/examples/ufos/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/maps/maps-walkthrough.md
+++ b/walkthroughs/week-4-libraries/maps/maps-walkthrough.md
@@ -56,7 +56,7 @@ file to include your API key where it currently contains `YOUR_API_KEY`. Then
 `cd` into the `hello-world` directory and run a dev server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 You should see a webpage that shows a Google Map.
@@ -205,15 +205,14 @@ When you're happy with your feature and you're ready to show it to the world,
 deploy it to your live server!
 
 Your
-<walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+<walkthrough-editor-open-file filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/README.md
+++ b/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/README.md
@@ -10,8 +10,8 @@ environment variable is set and that you've enabled the
 [Natural Language API](https://console.developers.google.com/apis/library/language.googleapis.com),
 and then execute this command:
 
-```
-mvn appengine:devserver
+```bash
+mvn package appengine:run
 ```
 
 Then navigate to `http://localhost:8080`.

--- a/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/pom.xml
+++ b/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/sentiment-analysis/examples/sentiment-analyzer/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/sentiment-analysis/sentiment-analysis-walkthrough.md
+++ b/walkthroughs/week-4-libraries/sentiment-analysis/sentiment-analysis-walkthrough.md
@@ -176,14 +176,14 @@ deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-4-libraries/translation/examples/minimal-google-translate/README.md
+++ b/walkthroughs/week-4-libraries/translation/examples/minimal-google-translate/README.md
@@ -9,6 +9,6 @@ environment variable is set and that you've enabled the
 [Translation API](https://console.cloud.google.com/apis/library/translate.googleapis.com),
 and then execute this command:
 
-```
-mvn appengine:devserver
+```bash
+mvn package appengine:run
 ```

--- a/walkthroughs/week-4-libraries/translation/examples/minimal-google-translate/pom.xml
+++ b/walkthroughs/week-4-libraries/translation/examples/minimal-google-translate/pom.xml
@@ -34,9 +34,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-4-libraries/translation/examples/minimal-google-translate/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-4-libraries/translation/examples/minimal-google-translate/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/walkthroughs/week-4-libraries/translation/translation-walkthrough.md
+++ b/walkthroughs/week-4-libraries/translation/translation-walkthrough.md
@@ -174,14 +174,14 @@ deploy it to your live server!
 
 Your
 <walkthrough-editor-open-file
-    filePath="step/portfolio/src/main/webapp/WEB-INF/appengine-web.xml">
-  appengine-web.xml
+    filePath="step/portfolio/pom.xml">
+  pom.xml
 </walkthrough-editor-open-file>
 file should already contain your project ID. If so, you can deploy to your live
 server by executing this command:
 
 ```bash
-mvn appengine:update
+mvn package appengine:deploy
 ```
 
 After the command successfully completes, you can navigate to

--- a/walkthroughs/week-5-tdd/intro/pom.xml
+++ b/walkthroughs/week-5-tdd/intro/pom.xml
@@ -36,9 +36,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-5-tdd/project/calendar-walkthrough.md
+++ b/walkthroughs/week-5-tdd/project/calendar-walkthrough.md
@@ -130,7 +130,7 @@ your algorithm.
 To run the web application, run a server:
 
 ```bash
-mvn appengine:devserver
+mvn package appengine:run
 ```
 
 Then open the web preview to view a webpage that shows a user interface that

--- a/walkthroughs/week-5-tdd/project/pom.xml
+++ b/walkthroughs/week-5-tdd/project/pom.xml
@@ -43,9 +43,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>com.google.appengine</groupId>
+        <groupId>com.google.cloud.tools</groupId>
         <artifactId>appengine-maven-plugin</artifactId>
-        <version>1.9.71</version>
+        <version>2.2.0</version>
+        <configuration>
+          <deploy.projectId>YOUR_PROJECT_ID_HERE</deploy.projectId>
+          <deploy.version>1</deploy.version>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/walkthroughs/week-5-tdd/project/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/walkthroughs/week-5-tdd/project/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
-  <application>YOUR_PROJECT_ID_HERE</application>
-  <version>1</version>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>


### PR DESCRIPTION
The updates on this CL are from the commits to the original repository (https://github.com/googleinterns/step/commits/master) after May 18, which is the date that I cloned the original repository. I have to include these changes in order to deploy my portfolio to cell-step-2020.appspot.com.