### PR TITLE
Add comment system to website, disable submit button based on text box

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -32,9 +32,6 @@ public class DataServlet extends HttpServlet {
   @Override
   public void init() {
     comments = new ArrayList<String>();
-    comments.add("This is the first comment.");
-    comments.add("The second comment is right here.");
-    comments.add("The third comment has arrived.");
   }
 
    /**
@@ -51,5 +48,27 @@ public class DataServlet extends HttpServlet {
     response.setContentType("text/html;");
     String json = convertToJsonUsingGson(comments);
     response.getWriter().println(json);
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("text/html;");
+    String comment = getParameter(request, "text-input", "");
+    comments.add(comment);
+
+    // Redirect back to the HTML page.
+    response.sendRedirect("/");
+  }
+
+  /**
+   * @return the request parameter, or the default value if the parameter
+   *         was not specified by the client
+   */
+  private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+    String value = request.getParameter(name);
+    if (value == null) {
+      return defaultValue;
+    }
+    return value;
   }
 }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -24,6 +24,7 @@
       <form action="/data" method="POST">
         <textarea id="comment-box" oninput="checkPostComment()" name="text-input" 
           minlength="1" placeholder="Join the discussion..."></textarea>
+        <br>
         <input id="comment-submit" type="submit" />
       </form>
       <div id="comment-container"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -22,7 +22,8 @@
       <div id="fact-container"></div>
       <h2>Comments</h2>
       <form action="/data" method="POST">
-        <textarea id="comment-box" oninput="checkPostComment()" name="text-input" minlength="1" placeholder="Join the discussion..."></textarea>
+        <textarea id="comment-box" oninput="checkPostComment()" name="text-input" 
+          minlength="1" placeholder="Join the discussion..."></textarea>
         <input id="comment-submit" type="submit" />
       </form>
       <div id="comment-container"></div>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -21,6 +21,10 @@
       <button id="fun-fact-hide" onclick="hideFunFact()">Hide fun fact</button>
       <div id="fact-container"></div>
       <h2>Comments</h2>
+      <form action="/data" method="POST">
+        <textarea id="comment-box" oninput="checkPostComment()" name="text-input" minlength="1" placeholder="Join the discussion..."></textarea>
+        <input id="comment-submit" type="submit" />
+      </form>
       <div id="comment-container"></div>
       <h2>Background</h2>
       <p>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -87,6 +87,8 @@ function fadeDiv(classOrIdName) {
 // Triggered upon DOM load.
 $(document).ready(() => {
   fadeDiv('.project');
+  disablePostComment();
+
   // Event every time user scrolls.
   $(window).scroll(() => {
     fadeDiv('.project');
@@ -108,7 +110,6 @@ $(document).ready(() => {
  */
 function addComments() {
   fetch('/data').then(response => response.json()).then((messages) => {
-    console.log("This is a test.");
     const commentContainer = document.getElementById('comment-container');
     messages.forEach((message) => {
       commentContainer.append(createListElement(message));
@@ -116,9 +117,30 @@ function addComments() {
   });
 }
 
-/** Creates an <li> element containing text. */
+/** 
+ * Creates an <li> element containing text. 
+ */
 function createListElement(text) {
   const liElement = document.createElement('li');
   liElement.innerText = text;
   return liElement;
+}
+
+/**
+ * Disables the "submit" comment button by default.
+ */
+function disablePostComment() {
+  document.getElementById('comment-submit').disabled = true;
+}
+
+/**
+ * Check if the comment box has text; if so, enable "submit" button.
+ */
+function checkPostComment() {
+  let commentText = document.getElementById('comment-box').value;
+  if (commentText === '') {
+    document.getElementById('comment-submit').disabled = true;
+  } else {
+    document.getElementById('comment-submit').disabled = false;
+  }
 }


### PR DESCRIPTION
Added a comment system to the website that lists comments as unordered list elements. The submit box is disabled on default, and enabled if any text is inside the comment box. This CL is merged into the **IntroJson** branch, as I needed to use the basic structure for adding <li> elements to the page (comments).