### PR TITLE
Add an email field to the comment, create User class.

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -37,13 +37,13 @@ import java.util.Date;
 public class DataServlet extends HttpServlet {
 
   // String identifiers for comment attributes.
-  final String COMMENT_TEXT = "text";
-  final String COMMENT_DATE = "date";
+  public final String COMMENT_TEXT = "text";
+  public final String COMMENT_DATE = "date";
   public final String COMMENT_EMAIL = "userEmail";
-  final String COMMENT_NAME = "Comment";
+  public final String COMMENT_NAME = "Comment";
 
   // Default for max number of comments to show.
-  final int COMMENT_MAX_DEFAULT = 5;
+  public final int COMMENT_MAX_DEFAULT = 5;
 
   // Maximum number of comments that are shown in UI.
   private int commentMax;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -129,17 +129,14 @@ public class DataServlet extends HttpServlet {
 
   /**
    * Returns the email address of the user, if the user is logged in.
-   * If no user is logged in, return an empty string (however, a user 
+   * If no user is logged in, return null (however, a user 
    * only has post access when logged in).
-   * 
-   * TODO: A user must be signed in to post a comment. However, what if there 
-   * is a bug? How should this be handled?
    */
   public String getUserEmail() {
     if (userService.isUserLoggedIn()) {
       return userService.getCurrentUser().getEmail();
     }
-    return "";
+    return null;
   }
 
   /**
@@ -148,7 +145,15 @@ public class DataServlet extends HttpServlet {
   public void postComment(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String text = getParameter(request, "text-input", "");
     Date date = new Date();
-    User user = new User(getUserEmail());
+    String email = getUserEmail();
+    
+    // Catch an unexpected error where the user posted a comment without logging in.
+    if (email == null) {
+      response.sendRedirect("/");
+      return;
+    }
+
+    User user = new User(email);
 
     // Create a comment entity from the Comment object.
     Comment commentObject = new Comment(text, date, user);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -126,6 +126,7 @@ $(document).ready(() => {
  */
 function addComments() {
   fetch('/data').then(response => response.json()).then((comments) => {
+    console.log(comments);
     const commentContainer = document.getElementById('comment-container');
     comments.forEach((comment) => {
       commentContainer.append(createComment(comment));

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -126,7 +126,6 @@ $(document).ready(() => {
  */
 function addComments() {
   fetch('/data').then(response => response.json()).then((comments) => {
-    console.log(comments);
     const commentContainer = document.getElementById('comment-container');
     comments.forEach((comment) => {
       commentContainer.append(createComment(comment));
@@ -150,6 +149,13 @@ function createComment(comment) {
   dateElement.innerText = comment.date + " UTC";
   dateElement.className = 'span-comment span-comment-date';
 
+  // Create span element holding the user email who posted the comment.
+  const userEmailElement = document.createElement('a');
+  userEmailElement.innerText = comment.user.emailAddress;
+  userEmailElement.href = 'mailto:' + comment.user.emailAddress;
+  userEmailElement.target = '_blank';
+  userEmailElement.className = 'span-comment span-comment-email';
+
   // Create a delete button that triggers another function.
   const deleteButtonElement = document.createElement('button');
   deleteButtonElement.innerText = 'Delete';
@@ -164,6 +170,7 @@ function createComment(comment) {
   // Add the text, date, and delete button to the comment.
   commentElement.appendChild(textElement);
   commentElement.appendChild(dateElement);
+  commentElement.appendChild(userEmailElement);
   commentElement.appendChild(deleteButtonElement);
   return commentElement;
 }


### PR DESCRIPTION
Now that users are required to sign in before posting a comment, the user's email is now displayed alongside the comment they post.

I created a separate User class, which right now only holds the email address, but will later be used to hold the user's nickname (and this could be followed by other attributes as well).

Note: The walkthrough did not specify any way to confirm that the user signing in is actually them (no email required).