### PR TITLE
Automatic username creation, ability to change username, and show username with comments.

### DIFF
--- a/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
@@ -104,8 +104,8 @@ public class AuthServlet extends HttpServlet {
   }
 
   /** 
-   * Returns the username of the user with id, or null if the user has not
-   * set a username.
+   * Returns the username of the user with id, or create an new username based
+   * off the input email if the user does not yet have a username.
    */
   public static String getUsername(String email, String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
@@ -157,14 +157,14 @@ public class AuthServlet extends HttpServlet {
     private String username;
 
     // Constructor to create UserAuth object with no user logged in.
-    // Empty strings represent no value (null is avoided to prevent errors).
+    // Null represents no value.
     private UserAuth(String loginUrl) {
-      this(false, loginUrl, "", "", "");
+      this(false, loginUrl, null, null, null);
     }
 
     // Constructor to create UserAuth object with user logged in.
     private UserAuth(String logoutUrl, String email, String username) {
-      this(true, "", logoutUrl, email, username);
+      this(true, null, logoutUrl, email, username);
     }
 
     // Full constructor to assign values to all fields.

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
@@ -130,7 +130,7 @@ public class AuthServlet extends HttpServlet {
    * If email does not contain an "@", return the email.
    */
   public static String createUsername(String email) {
-    if (!email.contains('@')) {
+    if (!email.contains("@")) {
       return email;
     }
     return email.substring(0, email.indexOf('@'));

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
@@ -36,21 +36,21 @@ public class AuthServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     response.setContentType("application/json");
 
-    final UserService userService = UserServiceFactory.getUserService();
-    final UserAuth userAuth;
+    UserService userService = UserServiceFactory.getUserService();
+    UserAuth userAuth;
     if (userService.isUserLoggedIn()) {
-      final String userEmail = userService.getCurrentUser().getEmail();
+      String userEmail = userService.getCurrentUser().getEmail();
       final String urlToRedirectToAfterUserLogsOut = "/";
-      final String logoutUrl = 
+      String logoutUrl = 
         userService.createLogoutURL(urlToRedirectToAfterUserLogsOut);
-      final String id = userService.getCurrentUser().getUserId();
-      final String username = getUsername(userEmail, id);
+      String id = userService.getCurrentUser().getUserId();
+      String username = getUsername(userEmail, id);
 
       // Create UserAuth object to represent logged-in user.
       userAuth = new UserAuth(logoutUrl, userEmail, username);
     } else {
       final String urlToRedirectToAfterUserLogsIn = "/";
-      final String loginUrl = userService.createLoginURL(urlToRedirectToAfterUserLogsIn);
+      String loginUrl = userService.createLoginURL(urlToRedirectToAfterUserLogsIn);
 
       // Create UserAuth object to represent logged-out user.
       userAuth = new UserAuth(loginUrl);
@@ -130,7 +130,7 @@ public class AuthServlet extends HttpServlet {
    * If email does not contain an "@", return the email.
    */
   public static String createUsername(String email) {
-    if (email.indexOf('@') == -1) {
+    if (!email.contains('@')) {
       return email;
     }
     return email.substring(0, email.indexOf('@'));

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
@@ -81,7 +81,7 @@ public class AuthServlet extends HttpServlet {
   /**
    * Add the username to the database, or replace the current username.
    */
-  private void putUsername(String username, String id) {
+  public static void putUsername(String username, String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Entity entity = new Entity("UserInfo", id);
     entity.setProperty("id", id);
@@ -107,7 +107,7 @@ public class AuthServlet extends HttpServlet {
    * Returns the username of the user with id, or null if the user has not
    * set a username.
    */
-  private String getUsername(String email, String id) {
+  public static String getUsername(String email, String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =
         new Query("UserInfo")
@@ -129,7 +129,7 @@ public class AuthServlet extends HttpServlet {
    * Create a username based on an email, by taking the portion before '@'.
    * If email does not contain an "@", return the email.
    */
-  private String createUsername(String email) {
+  public static String createUsername(String email) {
     if (email.indexOf('@') == -1) {
       return email;
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
@@ -14,20 +14,20 @@
 
 package com.google.sps.servlets;
 
-import com.google.appengine.api.users.UserService;
-import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import com.google.gson.Gson;
 
 @WebServlet("/auth")
 public class AuthServlet extends HttpServlet {

--- a/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/AuthServlet.java
@@ -16,6 +16,12 @@ package com.google.sps.servlets;
 
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.SortDirection;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -35,10 +41,13 @@ public class AuthServlet extends HttpServlet {
     if (userService.isUserLoggedIn()) {
       String userEmail = userService.getCurrentUser().getEmail();
       String urlToRedirectToAfterUserLogsOut = "/";
-      String logoutUrl = userService.createLogoutURL(urlToRedirectToAfterUserLogsOut);
+      String logoutUrl = 
+        userService.createLogoutURL(urlToRedirectToAfterUserLogsOut);
+      String id = userService.getCurrentUser().getUserId();
+      String username = getUsername(userEmail, id);
 
       // Create UserAuth object to represent logged-in user.
-      userAuth = new UserAuth(logoutUrl, userEmail);
+      userAuth = new UserAuth(logoutUrl, userEmail, username);
     } else {
       String urlToRedirectToAfterUserLogsIn = "/";
       String loginUrl = userService.createLoginURL(urlToRedirectToAfterUserLogsIn);
@@ -49,6 +58,82 @@ public class AuthServlet extends HttpServlet {
 
     String json = convertToJson(userAuth);
     response.getWriter().println(json);
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+
+    // TODO: What should I do if the user is not logged in, but still resets a username?
+    if (!userService.isUserLoggedIn()) {
+      response.sendRedirect("/");
+      return;
+    }
+
+    // Add the username to the database
+    String username = getParameter(request, "text-input", "");
+    String id = userService.getCurrentUser().getUserId();
+    putUsername(username, id);
+
+    response.sendRedirect("/");
+  }
+
+  /**
+   * Add the username to the database, or replace the current username.
+   */
+  private void putUsername(String username, String id) {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Entity entity = new Entity("UserInfo", id);
+    entity.setProperty("id", id);
+    entity.setProperty("username", username);
+    // The put() function automatically inserts new data or updates existing 
+    // data based on ID
+    datastore.put(entity);
+  }
+
+  /**
+   * @return the request parameter, or the default value if the parameter
+   *         was not specified by the client
+   */
+  private String getParameter(HttpServletRequest request, String name, String defaultValue) {
+    String value = request.getParameter(name);
+    if (value == null) {
+      return defaultValue;
+    }
+    return value;
+  }
+
+  /** 
+   * Returns the username of the user with id, or null if the user has not
+   * set a username.
+   */
+  private String getUsername(String email, String id) {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query =
+        new Query("UserInfo")
+            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+
+    // If user does not yet have username, create and add the username to datastore.
+    if (entity == null) {
+      String username = createUsername(email);
+      putUsername(username, id);
+      return username;
+    }
+    String username = (String) entity.getProperty("username");
+    return username;
+  }
+
+  /**
+   * Create a username based on an email, by taking the portion before '@'.
+   * If email does not contain an "@", return the email.
+   */
+  private String createUsername(String email) {
+    if (email.indexOf('@') == -1) {
+      return email;
+    }
+    return email.substring(0, email.indexOf('@'));
   }
 
   /**
@@ -69,25 +154,27 @@ public class AuthServlet extends HttpServlet {
     private String loginUrl;
     private String logoutUrl;
     private String email;
+    private String username;
 
     // Constructor to create UserAuth object with no user logged in.
-    // Empty strings represent no value (null is avoided).
+    // Empty strings represent no value (null is avoided to prevent errors).
     public UserAuth(String loginUrl) {
-      this(false, loginUrl, "", "");
+      this(false, loginUrl, "", "", "");
     }
 
     // Constructor to create UserAuth object with user logged in.
-    public UserAuth(String logoutUrl, String email) {
-      this(true, "", logoutUrl, email);
+    public UserAuth(String logoutUrl, String email, String username) {
+      this(true, "", logoutUrl, email, username);
     }
 
     // Full constructor to assign values to all fields.
     public UserAuth(boolean loggedIn, String loginUrl, String logoutUrl, 
-      String email) {
+      String email, String username) {
         this.loggedIn = loggedIn;
         this.loginUrl = loginUrl;
         this.logoutUrl = logoutUrl;
         this.email = email;
+        this.username = username;
     }
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -105,7 +105,7 @@ public class DataServlet extends HttpServlet {
       Date date = (Date) entity.getProperty(COMMENT_DATE);
       String email = (String) entity.getProperty(COMMENT_EMAIL);
       String userId = (String) entity.getProperty(COMMENT_ID);
-
+      
       // The username is not fetched from the entity as it could be updated.
       String username = AuthServlet.getUsername(email, userId);
       User user = new User(email, userId, username);
@@ -146,7 +146,7 @@ public class DataServlet extends HttpServlet {
     return null;
   }
 
-    /**
+  /**
    * Returns the id of the user, if the user is logged in.
    * If no user is logged in, return null (however, a user 
    * only has post access when logged in).

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,20 +14,20 @@
 
 package com.google.sps.servlets;
 
-import com.google.appengine.api.users.UserService;
-import com.google.appengine.api.users.UserServiceFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Date;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -40,6 +40,7 @@ public class DataServlet extends HttpServlet {
   final String COMMENT_TEXT = "text";
   final String COMMENT_DATE = "date";
   public final String COMMENT_EMAIL = "userEmail";
+  public final String COMMENT_ID = "id";
   public final String COMMENT_USERNAME = "username";
   final String COMMENT_NAME = "Comment";
 
@@ -102,8 +103,11 @@ public class DataServlet extends HttpServlet {
       String text = (String) entity.getProperty(COMMENT_TEXT);
       Date date = (Date) entity.getProperty(COMMENT_DATE);
       String email = (String) entity.getProperty(COMMENT_EMAIL);
-      String username = (String) entity.getProperty(COMMENT_USERNAME);
-      User user = new User(email, username);
+      String userId = (String) entity.getProperty(COMMENT_ID);
+
+      // The username is not fetched from the entity as it could be updated.
+      String username = AuthServlet.getUsername(email, userId);
+      User user = new User(email, userId, username);
       long id = entity.getKey().getId();
       Comment comment = new Comment(id, text, date, user);
       comments.add(comment);
@@ -141,7 +145,7 @@ public class DataServlet extends HttpServlet {
     if (userService.isUserLoggedIn()) {
       return userService.getCurrentUser().getEmail();
     }
-    return "";
+    return "zpchris@wharton.upenn.edu";
   }
 
     /**
@@ -168,8 +172,7 @@ public class DataServlet extends HttpServlet {
     String userEmail = getUserEmail();
     String userId = getUserId();
     String username = AuthServlet.getUsername(userEmail, userId);
-    User user = new User(userEmail, username);
-
+    User user = new User(userEmail, userId, username);
 
     // Create a comment entity from the Comment object.
     Comment commentObject = new Comment(text, date, user);
@@ -239,6 +242,7 @@ public class DataServlet extends HttpServlet {
       commentEntity.setProperty(COMMENT_TEXT, this.text);
       commentEntity.setProperty(COMMENT_DATE, this.date);
       commentEntity.setProperty(COMMENT_EMAIL, this.user.emailAddress);
+      commentEntity.setProperty(COMMENT_ID, this.user.id);
       commentEntity.setProperty(COMMENT_USERNAME, this.user.username);
       return commentEntity;
     }
@@ -249,11 +253,14 @@ public class DataServlet extends HttpServlet {
    */
   class User {
     // The fields that hold relevant user data.
+    // The id is used to keep the username up-to-date.
     private String emailAddress;
+    private String id;
     private String username;
 
-    public User(String emailAddress, String username) {
+    public User(String emailAddress, String id, String username) {
       this.emailAddress = emailAddress;
+      this.id = id;
       this.username = username;
     }
   }

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -25,9 +25,10 @@
       <div id="auth-username-container">
         <div id="auth-username-current"></div>
         <form action="/auth" method="POST">
-          <textarea id="username-box" name="text-input"
+          <textarea id="username-box" name="text-input" maxlength="16" 
             oninput="checkSubmit('username-box', 'username-submit')"  
-            minlength="1" placeholder="Enter a username..."></textarea>
+            placeholder="Enter a username (no spaces, sixteen chars max)..."
+            onkeypress="return event.charCode != 32"></textarea>
           <br>
           <input id="username-submit" type="submit" />
         </form>
@@ -36,7 +37,7 @@
         <form action="/data" method="POST">
           <textarea id="comment-box" name="text-input"
             oninput="checkSubmit('comment-box', 'comment-submit')"  
-            minlength="1" placeholder="Join the discussion..."></textarea>
+            placeholder="Join the discussion..."></textarea>
           <br>
           <input id="comment-submit" type="submit" />
         </form>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -22,6 +22,16 @@
       <div id="fact-container"></div>
       <h2>Comments</h2>
       <div id="auth-container"></div>
+      <div id="auth-username-container">
+        <div id="auth-username-current"></div>
+        <form action="/auth" method="POST">
+          <textarea id="username-box" name="text-input"
+            oninput="checkSubmit('username-box', 'username-submit')"  
+            minlength="1" placeholder="Enter a username..."></textarea>
+          <br>
+          <input id="username-submit" type="submit" />
+        </form>
+      </div>
       <div id="comment-section-container">
         <form action="/data" method="POST">
           <textarea id="comment-box" name="text-input"

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -235,6 +235,10 @@ function addAuth() {
 
     // Dynamically construct auth information based on user login status.
     if (authObj.loggedIn) {
+      // Create paragraph element holding the username.
+      const displayUsername = document.createElement('p');
+      displayUsername.innerText = authObj.username;
+
       // Create paragraph element holding the email.
       const displayEmail = document.createElement('p');
       displayEmail.innerText = 'Email: ' + authObj.email;
@@ -245,9 +249,15 @@ function addAuth() {
       logoutLink.href = authObj.logoutUrl;
 
       // Add the components to the auth-container div.
+      authContainerDiv.append(displayUsername);
       authContainerDiv.append(displayEmail);
       authContainerDiv.append(logoutLink);
     } else {
+      // Hide the "change username" container.
+      const changeUsernameContainer = 
+        document.getElementById('auth-username-container');
+      changeUsernameContainer.style.display = 'none';
+
       // Create link element that allows users to log in.
       const loginLink = document.createElement('a');
       loginLink.innerText = 'Login';

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -100,7 +100,8 @@ $(document).ready(() => {
   // Add frontend styling.
   fadeDiv('.project');
 
-  // Disable post comment and max comments shown submit buttons, by default.
+  // Disable post username, comment, and max comments shown submit buttons.
+  disableSubmit('username-submit');
   disableSubmit('comment-submit');
   disableSubmit('comment-max-submit');
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -150,9 +150,9 @@ function createComment(comment) {
   dateElement.innerText = comment.date + " UTC";
   dateElement.className = 'span-comment span-comment-date';
 
-  // Create span element holding the user email who posted the comment.
+  // Create span element holding the username and email who posted the comment.
   const userEmailElement = document.createElement('a');
-  userEmailElement.innerText = comment.user.emailAddress;
+  userEmailElement.innerText = comment.user.username;
   userEmailElement.href = 'mailto:' + comment.user.emailAddress;
   userEmailElement.target = '_blank';
   userEmailElement.className = 'span-comment span-comment-email';
@@ -238,7 +238,7 @@ function addAuth() {
     if (authObj.loggedIn) {
       // Create paragraph element holding the username.
       const displayUsername = document.createElement('p');
-      displayUsername.innerText = authObj.username;
+      displayUsername.innerText = 'Username: ' + authObj.username;
 
       // Create paragraph element holding the email.
       const displayEmail = document.createElement('p');

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -97,3 +97,7 @@ li {
   font-style: italic;
   color: rgb(160, 160, 160);
 }
+
+#auth-username-container {
+  margin: 10px 0;
+}

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -101,3 +101,7 @@ li {
 #auth-username-container {
   margin: 10px 0;
 }
+
+#comment-box, #username-box {
+  width: 250px;
+}


### PR DESCRIPTION
I handle the creation of a new username through the POST request of the `AuthServlet.java` servlet, through the `/auth` domain. When the user initially registers, their username is automatically created as the string before the `@` in their email; if they do not have an `@` in the email they entered (because this service does not check for email validity), their username is simply whatever email they entered. I then store this information in datastore as a `UserInfo` Entity -- this is the method used in the walkthrough.

I added another TODO similar to one a previous CL. Thus, I am not assigning this to any reviewers yet, as I will wait until that CL and TODO is addressed, so I can update this one accordingly.

I apologize for the large CL -- it turns out that adding a 'username' feature is a large task! I did my best to break it up into smaller commits, if you have any feedback on the size of this CL, please let me know!